### PR TITLE
Include the `terraform` version in the output of the version command

### DIFF
--- a/cli/cmds.go
+++ b/cli/cmds.go
@@ -317,5 +317,5 @@ func versionCmd(cmd *cobra.Command, args []string) {
 	}
 	terraformVersion := strings.SplitN(stdout.String(), "\n", 2)[0]
 	// nolint errcheck
-	fmt.Println(" . + " + terraformVersion)
+	fmt.Println("  + " + terraformVersion)
 }

--- a/cli/cmds.go
+++ b/cli/cmds.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/andreyvit/diff"
@@ -273,10 +275,7 @@ func Make() *cobra.Command {
 		Use:   "version",
 		Short: "Print the version number of terrafmt",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			//nolint errcheck
-			fmt.Println("terrafmt v" + version.Version + "-" + version.GitCommit)
-		},
+		Run:   versionCmd,
 	})
 
 	pflags := root.PersistentFlags()
@@ -301,4 +300,22 @@ func Make() *cobra.Command {
 	//todo bind to env?
 
 	return root
+}
+
+func versionCmd(cmd *cobra.Command, args []string) {
+	// nolint errcheck
+	fmt.Println("terrafmt v" + version.Version + "-" + version.GitCommit)
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	tfCmd := exec.Command("terraform", "version")
+	tfCmd.Stdout = stdout
+	tfCmd.Stderr = stderr
+	if err := tfCmd.Run(); err != nil {
+		common.Log.Warnf("Error running terraform: %s", err)
+		return
+	}
+	terraformVersion := strings.SplitN(stdout.String(), "\n", 2)[0]
+	// nolint errcheck
+	fmt.Println("+ " + terraformVersion)
 }

--- a/cli/cmds.go
+++ b/cli/cmds.go
@@ -317,5 +317,5 @@ func versionCmd(cmd *cobra.Command, args []string) {
 	}
 	terraformVersion := strings.SplitN(stdout.String(), "\n", 2)[0]
 	// nolint errcheck
-	fmt.Println("+ " + terraformVersion)
+	fmt.Println(" . + " + terraformVersion)
 }


### PR DESCRIPTION
Include the `terraform` version in the output of the version command, since `terrafmt` calls out to `terraform`. Different versions of `terraform` could have different formatting versions.

Question: If the installed version of `terraform` is outdated, should that be included in the version output of `terrafmt`? Currently it is not included.