### PR TITLE
Tolerate white-spaces on finish line beginning

### DIFF
--- a/cli/cmds.go
+++ b/cli/cmds.go
@@ -47,6 +47,7 @@ func Make() *cobra.Command {
 
 			pattern, _ := cmd.Flags().GetString("pattern")
 			filenames, err := allFiles(path, pattern)
+			fixFinishLines, _ := cmd.Flags().GetBool("fix-finish-lines")
 
 			if err != nil {
 				return err
@@ -81,6 +82,7 @@ func Make() *cobra.Command {
 
 						return err
 					},
+					FixFinishLines: fixFinishLines,
 				}
 				err := br.DoTheThing(filename)
 
@@ -116,6 +118,7 @@ func Make() *cobra.Command {
 	}
 
 	root.AddCommand(fmtCmd)
+	fmtCmd.Flags().Bool("fix-finish-lines", false, "fix block finish lines by removing any leading spaces")
 	fmtCmd.Flags().StringP("pattern", "p", "", "glob pattern to match with each file name (e.g. *.markdown)")
 
 	//options : only count, blocks diff/found, total lines diff, etc

--- a/lib/blocks/blockreader.go
+++ b/lib/blocks/blockreader.go
@@ -131,7 +131,7 @@ func (br *Reader) DoTheThing(filename string) error {
 					}
 
 					if err := br.LineRead(br, br.LineCount, l2); err != nil {
-						return fmt.Errorf("NB LineRead failed @ %s#%d for %s: %v", br.FileName, br.LineCount, l, err)
+						return fmt.Errorf("NB LineRead failed @ %s:%d for %s: %v", br.FileName, br.LineCount, l, err)
 					}
 
 					block = ""

--- a/lib/blocks/blockreader.go
+++ b/lib/blocks/blockreader.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/katbyte/terrafmt/lib/common"
@@ -57,9 +58,8 @@ func IsStartLine(line string) bool {
 }
 
 func IsFinishLine(line string) bool {
-	if line == "`)\n" { // acctest
-		return true
-	} else if strings.HasPrefix(line, "`,") { // acctest
+	matcher := regexp.MustCompile("^[[:space:]]*`(,|\\)\n)")
+	if matcher.MatchString(line) { // acctest
 		return true
 	} else if strings.HasPrefix(line, "```") { // documentation
 		return true

--- a/lib/blocks/blockreader.go
+++ b/lib/blocks/blockreader.go
@@ -34,7 +34,9 @@ type Reader struct {
 
 	ErrorBlocks int
 
-	ReadOnly bool
+	//options
+	ReadOnly       bool
+	FixFinishLines bool
 
 	//callbacks
 	LineRead  func(*Reader, int, string) error
@@ -142,7 +144,9 @@ func (br *Reader) DoTheThing(filename string) error {
 				}
 
 				if IsFinishLine(l2) {
-					l2 = lineWithLeadingSpacesMatcher.ReplaceAllString(l2, `$1`)
+					if br.FixFinishLines {
+						l2 = lineWithLeadingSpacesMatcher.ReplaceAllString(l2, `$1`)
+					}
 
 					br.LinesBlock += br.BlockCurrentLine
 

--- a/lib/blocks/blockreader.go
+++ b/lib/blocks/blockreader.go
@@ -58,8 +58,8 @@ func IsStartLine(line string) bool {
 }
 
 func IsFinishLine(line string) bool {
-	matcher := regexp.MustCompile("^[[:space:]]*`(,|\\)\n)")
-	if matcher.MatchString(line) { // acctest
+	spaceLeftAccTestMatcher := regexp.MustCompile("^[[:space:]]*`(,|\\)\n)")
+	if spaceLeftAccTestMatcher.MatchString(line) { // acctest
 		return true
 	} else if strings.HasPrefix(line, "```") { // documentation
 		return true
@@ -97,6 +97,8 @@ func (br *Reader) DoTheThing(filename string) error {
 			br.Writer = ioutil.Discard
 		}
 	}
+
+	spaceLeftMatcher := regexp.MustCompile("^[[:space:]]*(.*\n)$")
 
 	br.LineCount = 0
 	br.BlockCount = 0
@@ -138,6 +140,8 @@ func (br *Reader) DoTheThing(filename string) error {
 				}
 
 				if IsFinishLine(l2) {
+					l2 = spaceLeftMatcher.ReplaceAllString(l2, `$1`)
+
 					br.LinesBlock += br.BlockCurrentLine
 
 					// todo configure this behaviour with switch's

--- a/lib/blocks/blockreader.go
+++ b/lib/blocks/blockreader.go
@@ -14,6 +14,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var (
+	accTestFinishLineWithLeadingSpacesMatcher = regexp.MustCompile("^[[:space:]]*`(,|\\)\n)")
+	lineWithLeadingSpacesMatcher              = regexp.MustCompile("^[[:space:]]*(.*\n)$")
+)
+
 type Reader struct {
 	FileName string
 
@@ -58,8 +63,7 @@ func IsStartLine(line string) bool {
 }
 
 func IsFinishLine(line string) bool {
-	spaceLeftAccTestMatcher := regexp.MustCompile("^[[:space:]]*`(,|\\)\n)")
-	if spaceLeftAccTestMatcher.MatchString(line) { // acctest
+	if accTestFinishLineWithLeadingSpacesMatcher.MatchString(line) { // acctest
 		return true
 	} else if strings.HasPrefix(line, "```") { // documentation
 		return true
@@ -97,8 +101,6 @@ func (br *Reader) DoTheThing(filename string) error {
 			br.Writer = ioutil.Discard
 		}
 	}
-
-	spaceLeftMatcher := regexp.MustCompile("^[[:space:]]*(.*\n)$")
 
 	br.LineCount = 0
 	br.BlockCount = 0
@@ -140,7 +142,7 @@ func (br *Reader) DoTheThing(filename string) error {
 				}
 
 				if IsFinishLine(l2) {
-					l2 = spaceLeftMatcher.ReplaceAllString(l2, `$1`)
+					l2 = lineWithLeadingSpacesMatcher.ReplaceAllString(l2, `$1`)
 
 					br.LinesBlock += br.BlockCurrentLine
 

--- a/lib/blocks/blockreader_test.go
+++ b/lib/blocks/blockreader_test.go
@@ -1,0 +1,40 @@
+package blocks
+
+import "testing"
+
+func TestBlockReaderIsFinishLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		expected bool
+	}{
+		{
+			name:     "acctest without vars",
+			line:     "`)\n",
+			expected: true,
+		},
+		{
+			name:     "acctest with vars",
+			line:     "`,",
+			expected: true,
+		},
+		{
+			name:     "acctest without vars and whitespaces",
+			line:     "  `)\n",
+			expected: true,
+		},
+		{
+			name:     "acctest with vars and whitespaces",
+			line:     "  `,",
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := IsFinishLine(test.line)
+			if result != test.expected {
+				t.Errorf("Got: \n%#v\nexpected:\n%#v\n", result, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This relaxes finish line matching to support for white-spaces at the beginning and should partly address #11 (it still requires the finish line to not contain terraform code).

Maybe this could go a bit further and remove the spaces at the beginning of the matched finish line.