### PR TITLE
Add actionable error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ Use the `upgrade012` command to upgrade the blocks to 0.12:
 
 ![fmt](_docs/upgrade.png)
 
+### Exit codes
+
+To help usage of `terrafmt` in workflows, some commands will return actionable exit codes.
+
+If a Terraform parsing error is encountered in a block, the exit code is `2`.
+
+If the command `diff` with the `--check` flag enabled encounters a formatting difference, it will return `4`. If a file contains both blocks with parsing errors and a formatting difference, it will combine the exit codes to return `6`. These codes can be tested using bitwise checks.
+
 ## Development and Testing
 
 This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) for dependency management.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ If a Terraform parsing error is encountered in a block, the exit code is `2`.
 
 If the command `diff` with the `--check` flag enabled encounters a formatting difference, it will return `4`. If a file contains both blocks with parsing errors and a formatting difference, it will combine the exit codes to return `6`. These codes can be tested using bitwise checks.
 
+Otherwise, `terrafmt` will return `1` on an error.
+
 ## Development and Testing
 
 This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) for dependency management.

--- a/cli/blocks_test.go
+++ b/cli/blocks_test.go
@@ -16,7 +16,7 @@ type block struct {
 	text    string
 }
 
-var testcases = []struct {
+var blocksTestcases = []struct {
 	name           string
 	sourcefile     string
 	lineCount      int
@@ -109,6 +109,45 @@ var testcases = []struct {
 		},
 	},
 	{
+		name:       "Go bad terraform",
+		sourcefile: "testdata/bad_terraform.go",
+		lineCount:  20,
+		expectedBlocks: []block{
+			{
+				endLine: 12,
+				text: `rrrrrresource "aws_s3_bucket" "rrrrrrr" {
+  bucket =    "tf-test-bucket"
+}`,
+			},
+			{
+				endLine: 19,
+				text: `resource "aws_s3_bucket" "unclosed" {
+  bucket =    "tf-test-bucket"`,
+			},
+		},
+	},
+	{
+		name:       "Go unsupported format verbs",
+		sourcefile: "testdata/unsupported_fmt.go",
+		lineCount:  21,
+		expectedBlocks: []block{
+			{
+				endLine: 20,
+				text: `resource "aws_s3_bucket" "multi-verb" {
+  bucket =    "tf-test-bucket"
+
+  tags = {
+    %[1]q =    %[2]q
+    Test  =  "${%[5]s.name}"
+    Name  =       "${%s.name}"
+    byte       = "${aws_acm_certificate.test.*.arn[%[2]d]}"
+    Data  =    "${data.%s.name}"
+  }
+}`,
+			},
+		},
+	},
+	{
 		name:       "Markdown no change",
 		sourcefile: "testdata/no_diffs.md",
 		lineCount:  25,
@@ -171,7 +210,7 @@ var testcases = []struct {
 func TestCmdBlocksDefault(t *testing.T) {
 	t.Parallel()
 
-	for _, testcase := range testcases {
+	for _, testcase := range blocksTestcases {
 		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
@@ -210,7 +249,7 @@ func TestCmdBlocksDefault(t *testing.T) {
 func TestCmdBlocksVerbose(t *testing.T) {
 	t.Parallel()
 
-	for _, testcase := range testcases {
+	for _, testcase := range blocksTestcases {
 		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
@@ -239,7 +278,7 @@ func TestCmdBlocksVerbose(t *testing.T) {
 func TestCmdBlocksZeroTerminated(t *testing.T) {
 	t.Parallel()
 
-	for _, testcase := range testcases {
+	for _, testcase := range blocksTestcases {
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cli/diff_test.go
+++ b/cli/diff_test.go
@@ -11,57 +11,114 @@ import (
 	"github.com/spf13/afero"
 )
 
-func TestCmdDiffDefault(t *testing.T) {
-	testcases := []struct {
-		name       string
-		sourcefile string
-		resultfile string
-		noDiff     bool
-		errMsg     []string
-		fmtcompat  bool
-	}{
-		{
-			name:       "Go no change",
-			sourcefile: "testdata/no_diffs.go",
-			noDiff:     true,
+var diffTestcases = []struct {
+	name                  string
+	sourcefile            string
+	resultfile            string
+	noDiff                bool
+	lineCount             int
+	errorBlockCount       int
+	unformattedBlockCount int
+	totalBlockCount       int
+	errMsg                []string
+	fmtcompat             bool
+}{
+	{
+		name:            "Go no change",
+		sourcefile:      "testdata/no_diffs.go",
+		noDiff:          true,
+		lineCount:       29,
+		totalBlockCount: 3,
+	},
+	{
+		name:                  "Go formatting",
+		sourcefile:            "testdata/has_diffs.go",
+		resultfile:            "testdata/has_diffs_diff.go.txt",
+		lineCount:             39,
+		unformattedBlockCount: 2,
+		totalBlockCount:       4,
+	},
+	{
+		name:       "Go fmt verbs",
+		sourcefile: "testdata/fmt_compat.go",
+		resultfile: "testdata/fmt_compat_diff_nofmtcompat.go.txt",
+		fmtcompat:  false,
+		noDiff:     true,
+		errMsg: []string{
+			"block 1 @ %s:8 failed to process with: failed to parse hcl: testdata/fmt_compat.go:4,3-4:",
+			"block 3 @ %s:26 failed to process with: failed to parse hcl: testdata/fmt_compat.go:4,3-4:",
 		},
-		{
-			name:       "Go formatting",
-			sourcefile: "testdata/has_diffs.go",
-			resultfile: "testdata/has_diffs_diff.go.txt",
+		errorBlockCount: 2,
+		lineCount:       33,
+		totalBlockCount: 3,
+	},
+	{
+		name:                  "Go fmt verbs --fmtcompat",
+		sourcefile:            "testdata/fmt_compat.go",
+		resultfile:            "testdata/fmt_compat_diff_fmtcompat.go.txt",
+		fmtcompat:             true,
+		lineCount:             33,
+		unformattedBlockCount: 1,
+		totalBlockCount:       3,
+	},
+	{
+		name:       "Go bad terraform",
+		sourcefile: "testdata/bad_terraform.go",
+		resultfile: "testdata/bad_terraform_diff.go.txt",
+		errMsg: []string{
+			"block 2 @ %s:16 failed to process with: failed to parse hcl: testdata/bad_terraform.go:3,1-1:",
 		},
-		{
-			name:       "Go fmt verbs",
-			sourcefile: "testdata/fmt_compat.go",
-			resultfile: "testdata/fmt_compat_diff_nofmtcompat.go.txt",
-			fmtcompat:  false,
-			noDiff:     true,
-			errMsg: []string{
-				"block 1 @ testdata/fmt_compat.go:8 failed to process with: failed to parse hcl: testdata/fmt_compat.go:4,3-4:",
-				"block 3 @ testdata/fmt_compat.go:26 failed to process with: failed to parse hcl: testdata/fmt_compat.go:4,3-4:",
-			},
+		errorBlockCount:       1,
+		lineCount:             20,
+		unformattedBlockCount: 1,
+		totalBlockCount:       2,
+	},
+	{
+		name:       "Go unsupported format verbs",
+		sourcefile: "testdata/unsupported_fmt.go",
+		noDiff:     true,
+		errMsg: []string{
+			"block 1 @ %s:8 failed to process with: failed to parse hcl: testdata/unsupported_fmt.go:5,5-6:",
 		},
-		{
-			name:       "Go fmt verbs --fmtcompat",
-			sourcefile: "testdata/fmt_compat.go",
-			resultfile: "testdata/fmt_compat_diff_fmtcompat.go.txt",
-			fmtcompat:  true,
+		errorBlockCount:       1,
+		lineCount:             21,
+		unformattedBlockCount: 0,
+		totalBlockCount:       1,
+	},
+	{
+		name:       "Go unsupported format verbs --fmtcompat",
+		sourcefile: "testdata/unsupported_fmt.go",
+		noDiff:     true,
+		fmtcompat:  true,
+		errMsg: []string{
+			"block 1 @ %s:8 failed to process with: failed to parse hcl: testdata/unsupported_fmt.go:5,5-6:",
 		},
-		{
-			name:       "Markdown no change",
-			sourcefile: "testdata/no_diffs.md",
-			noDiff:     true,
-		},
-		{
-			name:       "Markdown formatting",
-			sourcefile: "testdata/has_diffs.md",
-			resultfile: "testdata/has_diffs_diff.md.txt",
-		},
-	}
+		errorBlockCount:       1,
+		lineCount:             21,
+		unformattedBlockCount: 0,
+		totalBlockCount:       1,
+	},
+	{
+		name:            "Markdown no change",
+		sourcefile:      "testdata/no_diffs.md",
+		noDiff:          true,
+		lineCount:       25,
+		totalBlockCount: 3,
+	},
+	{
+		name:                  "Markdown formatting",
+		sourcefile:            "testdata/has_diffs.md",
+		resultfile:            "testdata/has_diffs_diff.md.txt",
+		lineCount:             27,
+		unformattedBlockCount: 3,
+		totalBlockCount:       4,
+	},
+}
 
+func TestCmdDiffDefault(t *testing.T) {
 	t.Parallel()
 
-	for _, testcase := range testcases {
+	for _, testcase := range diffTestcases {
 		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
@@ -80,7 +137,7 @@ func TestCmdDiffDefault(t *testing.T) {
 			var outB strings.Builder
 			var errB strings.Builder
 			log := common.CreateLogger(&errB)
-			_, hasDiff, err := diffFile(fs, log, testcase.sourcefile, testcase.fmtcompat, false, nil, &outB, &errB)
+			br, hasDiff, err := diffFile(fs, log, testcase.sourcefile, testcase.fmtcompat, false, nil, &outB, &errB)
 			actualStdOut := outB.String()
 			actualStdErr := errB.String()
 
@@ -95,74 +152,27 @@ func TestCmdDiffDefault(t *testing.T) {
 				t.Errorf(("Expected diff, but did not get one"))
 			}
 
+			if testcase.errorBlockCount != br.ErrorBlocks {
+				t.Errorf("Expected %d block errors, got %d", testcase.errorBlockCount, br.ErrorBlocks)
+			}
+
 			if actualStdOut != expected {
 				t.Errorf("Output does not match expected:\n%s", diff.Diff(actualStdOut, expected))
 			}
 
-			checkExpectedErrors(t, actualStdErr, testcase.errMsg)
+			errMsg := []string{}
+			for _, msg := range testcase.errMsg {
+				errMsg = append(errMsg, fmt.Sprintf(msg, testcase.sourcefile))
+			}
+			checkExpectedErrors(t, actualStdErr, errMsg)
 		})
 	}
 }
 
 func TestCmdDiffVerbose(t *testing.T) {
-	testcases := []struct {
-		name                  string
-		sourcefile            string
-		noDiff                bool
-		lineCount             int
-		unformattedBlockCount int
-		totalBlockCount       int
-		fmtcompat             bool
-	}{
-		{
-			name:            "Go no change",
-			sourcefile:      "testdata/no_diffs.go",
-			noDiff:          true,
-			lineCount:       29,
-			totalBlockCount: 3,
-		},
-		{
-			name:                  "Go formatting",
-			sourcefile:            "testdata/has_diffs.go",
-			lineCount:             39,
-			unformattedBlockCount: 2,
-			totalBlockCount:       4,
-		},
-		{
-			name:            "Go fmt verbs",
-			sourcefile:      "testdata/fmt_compat.go",
-			noDiff:          true, // The only diff is in the block with the parsing error
-			lineCount:       33,
-			totalBlockCount: 3,
-			fmtcompat:       false,
-		},
-		{
-			name:                  "Go fmt verbs --fmtcompat",
-			sourcefile:            "testdata/fmt_compat.go",
-			lineCount:             33,
-			unformattedBlockCount: 1,
-			totalBlockCount:       3,
-			fmtcompat:             true,
-		},
-		{
-			name:            "Markdown no change",
-			sourcefile:      "testdata/no_diffs.md",
-			noDiff:          true,
-			lineCount:       25,
-			totalBlockCount: 3,
-		},
-		{
-			name:                  "Markdown formatting",
-			sourcefile:            "testdata/has_diffs.md",
-			lineCount:             27,
-			unformattedBlockCount: 3,
-			totalBlockCount:       4,
-		},
-	}
-
 	t.Parallel()
 
-	for _, testcase := range testcases {
+	for _, testcase := range diffTestcases {
 		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()

--- a/cli/diff_test.go
+++ b/cli/diff_test.go
@@ -35,6 +35,7 @@ func TestCmdDiffDefault(t *testing.T) {
 			sourcefile: "testdata/fmt_compat.go",
 			resultfile: "testdata/fmt_compat_diff_nofmtcompat.go.txt",
 			fmtcompat:  false,
+			noDiff:     true,
 			errMsg: []string{
 				"block 1 @ testdata/fmt_compat.go:8 failed to process with: failed to parse hcl: testdata/fmt_compat.go:4,3-4:",
 				"block 3 @ testdata/fmt_compat.go:26 failed to process with: failed to parse hcl: testdata/fmt_compat.go:4,3-4:",
@@ -79,12 +80,19 @@ func TestCmdDiffDefault(t *testing.T) {
 			var outB strings.Builder
 			var errB strings.Builder
 			log := common.CreateLogger(&errB)
-			_, _, err := diffFile(fs, log, testcase.sourcefile, testcase.fmtcompat, false, nil, &outB, &errB)
+			_, hasDiff, err := diffFile(fs, log, testcase.sourcefile, testcase.fmtcompat, false, nil, &outB, &errB)
 			actualStdOut := outB.String()
 			actualStdErr := errB.String()
 
 			if err != nil {
 				t.Fatalf("Got an error when none was expected: %v", err)
+			}
+
+			actualNoDiff := !hasDiff
+			if testcase.noDiff && !actualNoDiff {
+				t.Errorf("Expected no diff, but got one")
+			} else if !testcase.noDiff && actualNoDiff {
+				t.Errorf(("Expected diff, but did not get one"))
 			}
 
 			if actualStdOut != expected {

--- a/cli/testdata/bad_terraform.go
+++ b/cli/testdata/bad_terraform.go
@@ -1,0 +1,20 @@
+package test4
+
+import (
+	"fmt"
+)
+
+func testInvalidBlockName(randInt int) string {
+	return fmt.Sprintf(`
+rrrrrresource "aws_s3_bucket" "rrrrrrr" {
+  bucket =    "tf-test-bucket"
+}
+`, randInt)
+}
+
+func testUnclosedBlock(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "unclosed" {
+  bucket =    "tf-test-bucket"
+`, randInt)
+}

--- a/cli/testdata/bad_terraform_diff.go.txt
+++ b/cli/testdata/bad_terraform_diff.go.txt
@@ -1,0 +1,5 @@
+<lightMagenta>testdata/bad_terraform.go</><darkGray>:</><magenta>8</>
+ rrrrrresource "aws_s3_bucket" "rrrrrrr" {
+<red>-  bucket =    "tf-test-bucket"</>
+<green>+  bucket = "tf-test-bucket"</>
+ }

--- a/cli/testdata/bad_terraform_fmt.go
+++ b/cli/testdata/bad_terraform_fmt.go
@@ -1,0 +1,20 @@
+package test4
+
+import (
+	"fmt"
+)
+
+func testInvalidBlockName(randInt int) string {
+	return fmt.Sprintf(`
+rrrrrresource "aws_s3_bucket" "rrrrrrr" {
+  bucket = "tf-test-bucket"
+}
+`, randInt)
+}
+
+func testUnclosedBlock(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "unclosed" {
+  bucket =    "tf-test-bucket"
+`, randInt)
+}

--- a/cli/testdata/bad_terraform_upgrade012.go
+++ b/cli/testdata/bad_terraform_upgrade012.go
@@ -1,0 +1,21 @@
+package test4
+
+import (
+	"fmt"
+)
+
+func testInvalidBlockName(randInt int) string {
+	return fmt.Sprintf(`
+# TF-UPGRADE-TODO: Block type was not recognized, so this block and its contents were not automatically upgraded.
+rrrrrresource "aws_s3_bucket" "rrrrrrr" {
+  bucket = "tf-test-bucket"
+}
+`, randInt)
+}
+
+func testUnclosedBlock(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "unclosed" {
+  bucket =    "tf-test-bucket"
+`, randInt)
+}

--- a/cli/testdata/unsupported_fmt.go
+++ b/cli/testdata/unsupported_fmt.go
@@ -1,0 +1,21 @@
+package test6
+
+import (
+	"fmt"
+)
+
+func testUnsupportedFmtVerbs(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "multi-verb" {
+  bucket =    "tf-test-bucket"
+
+  tags = {
+    %[1]q =    %[2]q
+    Test  =  "${%[5]s.name}"
+    Name  =       "${%s.name}"
+    byte       = "${aws_acm_certificate.test.*.arn[%[2]d]}"
+    Data  =    "${data.%s.name}"
+  }
+}
+`, randInt)
+}

--- a/cli/upgrade012_test.go
+++ b/cli/upgrade012_test.go
@@ -11,56 +11,110 @@ import (
 	"github.com/spf13/afero"
 )
 
-func TestCmdUpgrade012StdinDefault(t *testing.T) {
-	testcases := []struct {
-		name       string
-		sourcefile string
-		resultfile string
-		noDiff     bool
-		errMsg     []string
-		fmtcompat  bool
-	}{
-		{
-			name:       "Go no change",
-			sourcefile: "testdata/no_diffs.go",
-			noDiff:     true,
+var upgradeTestcases = []struct {
+	name              string
+	sourcefile        string
+	resultfile        string
+	noDiff            bool
+	errMsg            []string
+	fmtcompat         bool
+	lineCount         int
+	errorBlockCount   int
+	updatedBlockCount int
+	totalBlockCount   int
+}{
+	{
+		name:            "Go no change",
+		sourcefile:      "testdata/no_diffs.go",
+		noDiff:          true,
+		lineCount:       29,
+		totalBlockCount: 3,
+	},
+	{
+		name:              "Go formatting",
+		sourcefile:        "testdata/has_diffs.go",
+		resultfile:        "testdata/has_diffs_upgrade012.go", // This has stricter formatting than `fmt`
+		lineCount:         39,
+		updatedBlockCount: 2,
+		totalBlockCount:   4,
+	},
+	{
+		name:       "Go fmt verbs",
+		sourcefile: "testdata/fmt_compat.go",
+		noDiff:     true,
+		fmtcompat:  false,
+		errMsg: []string{
+			"block 1 @ %s:8 failed to process with: cmd.Run() failed in terraform init with exit status 1:",
+			"block 3 @ %s:26 failed to process with: cmd.Run() failed in terraform init with exit status 1:",
 		},
-		{
-			name:       "Go formatting",
-			sourcefile: "testdata/has_diffs.go",
-			resultfile: "testdata/has_diffs_upgrade012.go", // This has stricter formatting than `fmt`
+		lineCount:       33,
+		totalBlockCount: 3,
+	},
+	{
+		name:              "Go fmt verbs --fmtcompat",
+		sourcefile:        "testdata/fmt_compat.go",
+		resultfile:        "testdata/fmt_compat_upgrade012.go",
+		fmtcompat:         true,
+		lineCount:         33,
+		updatedBlockCount: 2,
+		totalBlockCount:   3,
+	},
+	{
+		name:       "Go bad terraform",
+		sourcefile: "testdata/bad_terraform.go",
+		resultfile: "testdata/bad_terraform_upgrade012.go",
+		errMsg: []string{
+			"block 2 @ %s:16 failed to process with: cmd.Run() failed in terraform init with exit status 1:",
 		},
-		{
-			name:       "Go fmt verbs",
-			sourcefile: "testdata/fmt_compat.go",
-			noDiff:     true,
-			fmtcompat:  false,
-			errMsg: []string{
-				"block 1 @ stdin:8 failed to process with: cmd.Run() failed in terraform init with exit status 1:",
-				"block 3 @ stdin:26 failed to process with: cmd.Run() failed in terraform init with exit status 1:",
-			},
+		errorBlockCount:   1,
+		lineCount:         20,
+		updatedBlockCount: 1,
+		totalBlockCount:   2,
+	},
+	{
+		name:       "Go unsupported format verbs",
+		sourcefile: "testdata/unsupported_fmt.go",
+		noDiff:     true,
+		errMsg: []string{
+			"block 1 @ %s:8 failed to process with: cmd.Run() failed in terraform init with exit status 1:",
 		},
-		{
-			name:       "Go fmt verbs --fmtcompat",
-			sourcefile: "testdata/fmt_compat.go",
-			resultfile: "testdata/fmt_compat_upgrade012.go",
-			fmtcompat:  true,
+		errorBlockCount: 1,
+		lineCount:       21,
+		totalBlockCount: 1,
+	},
+	{
+		name:       "Go unsupported format verbs --fmtcompat",
+		sourcefile: "testdata/unsupported_fmt.go",
+		noDiff:     true,
+		fmtcompat:  true,
+		errMsg: []string{
+			"block 1 @ %s:8 failed to process with: cmd.Run() failed in terraform init with exit status 1:",
 		},
-		{
-			name:       "Markdown no change",
-			sourcefile: "testdata/no_diffs.md",
-			noDiff:     true,
-		},
-		{
-			name:       "Markdown formatting",
-			sourcefile: "testdata/has_diffs.md",
-			resultfile: "testdata/has_diffs_upgrade012.md", // This has stricter formatting than `fmt`
-		},
-	}
+		errorBlockCount: 1,
+		lineCount:       21,
+		totalBlockCount: 1,
+	},
+	{
+		name:            "Markdown no change",
+		sourcefile:      "testdata/no_diffs.md",
+		noDiff:          true,
+		lineCount:       25,
+		totalBlockCount: 3,
+	},
+	{
+		name:              "Markdown formatting",
+		sourcefile:        "testdata/has_diffs.md",
+		resultfile:        "testdata/has_diffs_upgrade012.md", // This has stricter formatting than `fmt`
+		lineCount:         27,
+		updatedBlockCount: 3,
+		totalBlockCount:   4,
+	},
+}
 
+func TestCmdUpgrade012StdinDefault(t *testing.T) {
 	t.Parallel()
 
-	for _, testcase := range testcases {
+	for _, testcase := range upgradeTestcases {
 		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
@@ -97,70 +151,19 @@ func TestCmdUpgrade012StdinDefault(t *testing.T) {
 				t.Errorf("Output does not match expected:\n%s", diff.Diff(actualStdOut, expected))
 			}
 
-			checkExpectedErrors(t, actualStdErr, testcase.errMsg)
+			errMsg := []string{}
+			for _, msg := range testcase.errMsg {
+				errMsg = append(errMsg, fmt.Sprintf(msg, "stdin"))
+			}
+			checkExpectedErrors(t, actualStdErr, errMsg)
 		})
 	}
 }
 
 func TestCmdUpgrade012StdinVerbose(t *testing.T) {
-	testcases := []struct {
-		name              string
-		sourcefile        string
-		noDiff            bool
-		lineCount         int
-		updatedBlockCount int
-		totalBlockCount   int
-		fmtcompat         bool
-	}{
-		{
-			name:            "Go no change",
-			sourcefile:      "testdata/no_diffs.go",
-			noDiff:          true,
-			lineCount:       29,
-			totalBlockCount: 3,
-		},
-		{
-			name:              "Go formatting",
-			sourcefile:        "testdata/has_diffs.go",
-			lineCount:         39,
-			updatedBlockCount: 2,
-			totalBlockCount:   4,
-		},
-		{
-			name:            "Go fmt verbs",
-			sourcefile:      "testdata/fmt_compat.go",
-			noDiff:          true,
-			lineCount:       33,
-			totalBlockCount: 3,
-			fmtcompat:       false,
-		},
-		{
-			name:              "Go fmt verbs --fmtcompat",
-			sourcefile:        "testdata/fmt_compat.go",
-			lineCount:         33,
-			updatedBlockCount: 2,
-			totalBlockCount:   3,
-			fmtcompat:         true,
-		},
-		{
-			name:            "Markdown no change",
-			sourcefile:      "testdata/no_diffs.md",
-			noDiff:          true,
-			lineCount:       25,
-			totalBlockCount: 3,
-		},
-		{
-			name:              "Markdown formatting",
-			sourcefile:        "testdata/has_diffs.md",
-			lineCount:         27,
-			updatedBlockCount: 3,
-			totalBlockCount:   4,
-		},
-	}
-
 	t.Parallel()
 
-	for _, testcase := range testcases {
+	for _, testcase := range upgradeTestcases {
 		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
@@ -206,55 +209,9 @@ func TestCmdUpgrade012StdinVerbose(t *testing.T) {
 }
 
 func TestCmdUpgrade012FileDefault(t *testing.T) {
-	testcases := []struct {
-		name       string
-		sourcefile string
-		resultfile string
-		noDiff     bool
-		errMsg     []string
-		fmtcompat  bool
-	}{
-		{
-			name:       "Go no change",
-			sourcefile: "testdata/no_diffs.go",
-			noDiff:     true,
-		},
-		{
-			name:       "Go formatting",
-			sourcefile: "testdata/has_diffs.go",
-			resultfile: "testdata/has_diffs_upgrade012.go", // This has stricter formatting than `fmt`
-		},
-		{
-			name:       "Go fmt verbs",
-			sourcefile: "testdata/fmt_compat.go",
-			noDiff:     true,
-			fmtcompat:  false,
-			errMsg: []string{
-				"block 1 @ testdata/fmt_compat.go:8 failed to process with: cmd.Run() failed in terraform init with exit status 1:",
-				"block 3 @ testdata/fmt_compat.go:26 failed to process with: cmd.Run() failed in terraform init with exit status 1:",
-			},
-		},
-		{
-			name:       "Go fmt verbs --fmtcompat",
-			sourcefile: "testdata/fmt_compat.go",
-			resultfile: "testdata/fmt_compat_upgrade012.go",
-			fmtcompat:  true,
-		},
-		{
-			name:       "Markdown no change",
-			sourcefile: "testdata/no_diffs.md",
-			noDiff:     true,
-		},
-		{
-			name:       "Markdown formatting",
-			sourcefile: "testdata/has_diffs.md",
-			resultfile: "testdata/has_diffs_upgrade012.md", // This has stricter formatting than `fmt`
-		},
-	}
-
 	t.Parallel()
 
-	for _, testcase := range testcases {
+	for _, testcase := range upgradeTestcases {
 		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
@@ -298,70 +255,19 @@ func TestCmdUpgrade012FileDefault(t *testing.T) {
 				t.Errorf("File does not match expected:\n%s", diff.Diff(actualContent, expected))
 			}
 
-			checkExpectedErrors(t, actualStdErr, testcase.errMsg)
+			errMsg := []string{}
+			for _, msg := range testcase.errMsg {
+				errMsg = append(errMsg, fmt.Sprintf(msg, testcase.sourcefile))
+			}
+			checkExpectedErrors(t, actualStdErr, errMsg)
 		})
 	}
 }
 
 func TestCmdUpgrade012FileVerbose(t *testing.T) {
-	testcases := []struct {
-		name              string
-		sourcefile        string
-		noDiff            bool
-		lineCount         int
-		updatedBlockCount int
-		totalBlockCount   int
-		fmtcompat         bool
-	}{
-		{
-			name:            "Go no change",
-			sourcefile:      "testdata/no_diffs.go",
-			noDiff:          true,
-			lineCount:       29,
-			totalBlockCount: 3,
-		},
-		{
-			name:              "Go formatting",
-			sourcefile:        "testdata/has_diffs.go",
-			lineCount:         39,
-			updatedBlockCount: 2,
-			totalBlockCount:   4,
-		},
-		{
-			name:            "Go fmt verbs",
-			sourcefile:      "testdata/fmt_compat.go",
-			noDiff:          true,
-			lineCount:       33,
-			totalBlockCount: 3,
-			fmtcompat:       false,
-		},
-		{
-			name:              "Go fmt verbs --fmtcompat",
-			sourcefile:        "testdata/fmt_compat.go",
-			lineCount:         33,
-			updatedBlockCount: 2,
-			totalBlockCount:   3,
-			fmtcompat:         true,
-		},
-		{
-			name:            "Markdown no change",
-			sourcefile:      "testdata/no_diffs.md",
-			noDiff:          true,
-			lineCount:       25,
-			totalBlockCount: 3,
-		},
-		{
-			name:              "Markdown formatting",
-			sourcefile:        "testdata/has_diffs.md",
-			lineCount:         27,
-			updatedBlockCount: 3,
-			totalBlockCount:   4,
-		},
-	}
-
 	t.Parallel()
 
-	for _, testcase := range testcases {
+	for _, testcase := range upgradeTestcases {
 		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Returns specific error codes when a Terraform block parsing error or difference is encountered.

Not evaluated/Parsing error | Unformatted | Code
-------------|---------------|------
Y | N | `2`
N | Y | `4`
Y | Y | `6`

Other errors should return the code `1`.

Closes #32 