### PR TITLE
Add support for return `...` blocks in acctest

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The tool currently supports blocks with the following start and end lines:
 |```terraform        |`,  |
 |return fmt.Sprintf(`|`,  |
 |return fmt.Sprintf(`|`)  |
+|return `            |`   |
 
 ### Extract Terraform Blocks
 

--- a/lib/blocks/blockreader.go
+++ b/lib/blocks/blockreader.go
@@ -64,6 +64,8 @@ func ReaderIgnore(br *Reader, number int, line string) error {
 func IsStartLine(line string) bool {
 	if strings.HasSuffix(line, "return fmt.Sprintf(`\n") { // acctest
 		return true
+	} else if strings.HasSuffix(line, "return `\n") { // acctest
+		return true
 	} else if strings.HasPrefix(line, "```hcl") { // documentation
 		return true
 	} else if strings.HasPrefix(line, "```terraform") { // documentation
@@ -77,6 +79,8 @@ func IsStartLine(line string) bool {
 
 func IsFinishLine(line string) bool {
 	if accTestFinishLineWithLeadingSpacesMatcher.MatchString(line) { // acctest
+		return true
+	} else if strings.HasSuffix(line, "`\n") { // acctest
 		return true
 	} else if strings.HasPrefix(line, "```") { // documentation
 		return true

--- a/lib/blocks/testdata/test1.go
+++ b/lib/blocks/testdata/test1.go
@@ -12,6 +12,14 @@ resource "aws_s3_bucket" "simple" {
 `)
 }
 
+func testReturnStringSimple() string {
+	return `
+resource "aws_s3_bucket" "simple2" {
+  bucket = "tf-test-bucket-simple2"
+}
+`
+}
+
 func testReturnSprintfWithParameters(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "with-parameters" {

--- a/lib/blocks/testdata/test1_results.yaml
+++ b/lib/blocks/testdata/test1_results.yaml
@@ -4,6 +4,10 @@ expected_results:
       bucket = "tf-test-bucket-simple"
     }
   - |
+    resource "aws_s3_bucket" "simple2" {
+      bucket = "tf-test-bucket-simple2"
+    }
+  - |
     resource "aws_s3_bucket" "with-parameters" {
       bucket = "tf-test-bucket-with-parameters-%d"
     }


### PR DESCRIPTION
In some cases, usage of fmt.Sprintf() is useless in acctest. Return string with back quote is more simple.
Example :
```
func testReturnStringSimple() string {
	return `
resource "aws_s3_bucket" "simple2" {
  bucket = "tf-test-bucket-simple2"
}
`
}
```