### PR TITLE
Handles functions with an arbitrary number of parameters

### DIFF
--- a/cli/blocks_test.go
+++ b/cli/blocks_test.go
@@ -100,7 +100,7 @@ var blocksTestcases = []struct {
 	{
 		name:       "Go fmt verbs",
 		sourcefile: "testdata/fmt_compat.go",
-		lineCount:  41,
+		lineCount:  55,
 		expectedBlocks: []block{
 			{
 				startLine: 8,
@@ -132,6 +132,19 @@ var blocksTestcases = []struct {
 
   tags = {
     %[1]q    = %[2]q
+  }
+}`,
+			},
+			{
+				startLine: 44,
+				endLine:   54,
+				text: `resource "aws_elasticache_replication_group" "for-expression" {
+  replication_group_id = %[1]q
+
+  node_groups {
+    primary_availability_zone  = aws_subnet.test[0].availability_zone
+    replica_availability_zones = [for x in range(1, %[2]d+1) : element(aws_subnet.test[*].availability_zone, x)]
+    replica_count              = %[2]d
   }
 }`,
 			},

--- a/cli/diff_test.go
+++ b/cli/diff_test.go
@@ -17,7 +17,6 @@ var diffTestcases = []struct {
 	resultfile            string
 	noDiff                bool
 	lineCount             int
-	errorBlockCount       int
 	unformattedBlockCount int
 	totalBlockCount       int
 	errMsg                []string
@@ -47,19 +46,19 @@ var diffTestcases = []struct {
 		errMsg: []string{
 			"block 1 @ %s:8 failed to process with: failed to parse hcl: testdata/fmt_compat.go:4,3-4:",
 			"block 3 @ %s:30 failed to process with: failed to parse hcl: testdata/fmt_compat.go:4,3-4:",
+			"block 4 @ %s:44 failed to process with: failed to parse hcl: testdata/fmt_compat.go:2,26-27:",
 		},
-		lineCount:       41,
-		errorBlockCount: 2,
-		totalBlockCount: 3,
+		lineCount:       55,
+		totalBlockCount: 4,
 	},
 	{
 		name:                  "Go fmt verbs --fmtcompat",
 		sourcefile:            "testdata/fmt_compat.go",
 		resultfile:            "testdata/fmt_compat_diff_fmtcompat.go.txt",
 		fmtcompat:             true,
-		lineCount:             41,
-		unformattedBlockCount: 1,
-		totalBlockCount:       3,
+		lineCount:             55,
+		unformattedBlockCount: 2,
+		totalBlockCount:       4,
 	},
 	{
 		name:       "Go bad terraform",
@@ -68,7 +67,6 @@ var diffTestcases = []struct {
 		errMsg: []string{
 			"block 2 @ %s:16 failed to process with: failed to parse hcl: testdata/bad_terraform.go:3,1-1:",
 		},
-		errorBlockCount:       1,
 		lineCount:             20,
 		unformattedBlockCount: 1,
 		totalBlockCount:       2,
@@ -80,7 +78,6 @@ var diffTestcases = []struct {
 		errMsg: []string{
 			"block 1 @ %s:8 failed to process with: failed to parse hcl: testdata/unsupported_fmt.go:5,5-6:",
 		},
-		errorBlockCount:       1,
 		lineCount:             21,
 		unformattedBlockCount: 0,
 		totalBlockCount:       1,
@@ -93,7 +90,6 @@ var diffTestcases = []struct {
 		errMsg: []string{
 			"block 1 @ %s:8 failed to process with: failed to parse hcl: testdata/unsupported_fmt.go:6,17-18:",
 		},
-		errorBlockCount:       1,
 		lineCount:             21,
 		unformattedBlockCount: 0,
 		totalBlockCount:       1,
@@ -152,8 +148,8 @@ func TestCmdDiffDefault(t *testing.T) {
 				t.Errorf(("Expected diff, but did not get one"))
 			}
 
-			if testcase.errorBlockCount != br.ErrorBlocks {
-				t.Errorf("Expected %d block errors, got %d", testcase.errorBlockCount, br.ErrorBlocks)
+			if len(testcase.errMsg) != br.ErrorBlocks {
+				t.Errorf("Expected %d block errors, got %d", len(testcase.errMsg), br.ErrorBlocks)
 			}
 
 			if actualStdOut != expected {

--- a/cli/fmt_test.go
+++ b/cli/fmt_test.go
@@ -20,7 +20,6 @@ var fmtTestcases = []struct {
 	fmtcompat         bool
 	fixFinishLines    bool
 	lineCount         int
-	errorBlockCount   int
 	updatedBlockCount int
 	totalBlockCount   int
 }{
@@ -56,19 +55,19 @@ var fmtTestcases = []struct {
 		errMsg: []string{
 			"block 1 @ %s:8 failed to process with: failed to parse hcl: %s:4,3-4:",
 			"block 3 @ %s:30 failed to process with: failed to parse hcl: %s:4,3-4:",
+			"block 4 @ %s:44 failed to process with: failed to parse hcl: %s:2,26-27:",
 		},
-		lineCount:       41,
-		errorBlockCount: 2,
-		totalBlockCount: 3,
+		lineCount:       55,
+		totalBlockCount: 4,
 	},
 	{
 		name:              "Go fmt verbs --fmtcompat",
 		sourcefile:        "testdata/fmt_compat.go",
 		resultfile:        "testdata/fmt_compat_fmtcompat.go",
 		fmtcompat:         true,
-		lineCount:         41,
-		updatedBlockCount: 1,
-		totalBlockCount:   3,
+		lineCount:         55,
+		updatedBlockCount: 2,
+		totalBlockCount:   4,
 	},
 	{
 		name:       "Go bad terraform",
@@ -77,7 +76,6 @@ var fmtTestcases = []struct {
 		errMsg: []string{
 			"block 2 @ %s:16 failed to process with: failed to parse hcl: %s:3,1-1:",
 		},
-		errorBlockCount:   1,
 		lineCount:         20,
 		updatedBlockCount: 1,
 		totalBlockCount:   2,
@@ -89,7 +87,6 @@ var fmtTestcases = []struct {
 		errMsg: []string{
 			"block 1 @ %s:8 failed to process with: failed to parse hcl: %s:5,5-6:",
 		},
-		errorBlockCount: 1,
 		lineCount:       21,
 		totalBlockCount: 1,
 	},
@@ -101,7 +98,6 @@ var fmtTestcases = []struct {
 		errMsg: []string{
 			"block 1 @ %s:8 failed to process with: failed to parse hcl: %s:6,17-18:",
 		},
-		errorBlockCount: 1,
 		lineCount:       21,
 		totalBlockCount: 1,
 	},
@@ -168,8 +164,8 @@ func TestCmdFmtStdinDefault(t *testing.T) {
 				t.Fatalf("Case %q: Got an error when none was expected: %v", testcase.name, err)
 			}
 
-			if testcase.errorBlockCount != br.ErrorBlocks {
-				t.Errorf("Expected %d block errors, got %d", testcase.errorBlockCount, br.ErrorBlocks)
+			if len(testcase.errMsg) != br.ErrorBlocks {
+				t.Errorf("Expected %d block errors, got %d", len(testcase.errMsg), br.ErrorBlocks)
 			}
 
 			if actualStdOut != expected {
@@ -281,8 +277,8 @@ func TestCmdFmtFileDefault(t *testing.T) {
 				t.Errorf("Case %q: File does not match expected: ('-' actual, '+' expected)\n%s", testcase.name, diff.Diff(actualContent, expected))
 			}
 
-			if testcase.errorBlockCount != br.ErrorBlocks {
-				t.Errorf("Expected %d block errors, got %d", testcase.errorBlockCount, br.ErrorBlocks)
+			if len(testcase.errMsg) != br.ErrorBlocks {
+				t.Errorf("Expected %d block errors, got %d", len(testcase.errMsg), br.ErrorBlocks)
 			}
 
 			errMsg := []string{}

--- a/cli/testdata/fmt_compat.go
+++ b/cli/testdata/fmt_compat.go
@@ -39,3 +39,17 @@ resource "aws_s3_bucket" "extra-space" {
 }
 `, randInt) + testReturnSprintfSimple()
 }
+
+func testForExpression(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "for-expression" {
+  replication_group_id = %[1]q
+
+  node_groups {
+    primary_availability_zone  = aws_subnet.test[0].availability_zone
+    replica_availability_zones = [for x in range(1, %[2]d+1) : element(aws_subnet.test[*].availability_zone, x)]
+    replica_count              = %[2]d
+  }
+}
+`, randInt)
+}

--- a/cli/testdata/fmt_compat_diff_fmtcompat.go.txt
+++ b/cli/testdata/fmt_compat_diff_fmtcompat.go.txt
@@ -10,3 +10,14 @@
 <green>+    %[1]q = %[2]q</>
    }
  }
+<lightMagenta>testdata/fmt_compat.go</><darkGray>:</><magenta>44</>
+ resource "aws_elasticache_replication_group" "for-expression" {
+   replication_group_id = %[1]q
+ 
+   node_groups {
+     primary_availability_zone  = aws_subnet.test[0].availability_zone
+<red>-    replica_availability_zones = [for x in range(1, %[2]d+1) : element(aws_subnet.test[*].availability_zone, x)]</>
+<green>+    replica_availability_zones = [for x in range(1, %[2]d + 1) : element(aws_subnet.test[*].availability_zone, x)]</>
+     replica_count              = %[2]d
+   }
+ }

--- a/cli/testdata/fmt_compat_fmtcompat.go
+++ b/cli/testdata/fmt_compat_fmtcompat.go
@@ -39,3 +39,17 @@ resource "aws_s3_bucket" "extra-space" {
 }
 `, randInt) + testReturnSprintfSimple()
 }
+
+func testForExpression(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "for-expression" {
+  replication_group_id = %[1]q
+
+  node_groups {
+    primary_availability_zone  = aws_subnet.test[0].availability_zone
+    replica_availability_zones = [for x in range(1, %[2]d + 1) : element(aws_subnet.test[*].availability_zone, x)]
+    replica_count              = %[2]d
+  }
+}
+`, randInt)
+}

--- a/cli/testdata/fmt_compat_upgrade012.go
+++ b/cli/testdata/fmt_compat_upgrade012.go
@@ -39,3 +39,17 @@ resource "aws_s3_bucket" "extra-space" {
 }
 `, randInt) + testReturnSprintfSimple()
 }
+
+func testForExpression(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "for-expression" {
+  replication_group_id = %[1]q
+
+  node_groups {
+    primary_availability_zone  = aws_subnet.test[0].availability_zone
+    replica_availability_zones = [for x in range(1, %[2]d+1) : element(aws_subnet.test[*].availability_zone, x)]
+    replica_count              = %[2]d
+  }
+}
+`, randInt)
+}

--- a/lib/fmtverbs/fmtverbs_test.go
+++ b/lib/fmtverbs/fmtverbs_test.go
@@ -226,12 +226,16 @@ resource "resource" "test" {
 resource "resource" "test" {
   kat  = base64encode(%s)
   byte = md5(data.source.%s.id)
+  kat  = base64encode(%[1]s)
+  byte = md5(data.source.%[1]s.id)
 }
 `,
 			expected: `
 resource "resource" "test" {
-  kat  = base64encode(TFFMTKTBRACKETPERCENTs)
+  kat  = base64encode(TFMTFNPARAM_s)
   byte = md5(data.source.TFMTKTKTTFMTs.id)
+  kat  = base64encode(TFMTFNPARAM_1s)
+  byte = md5(data.source.TFMTKTKTTFMT_1s.id)
 }
 `,
 		},
@@ -429,6 +433,29 @@ resource "resource" "test" {
   attr = "${aws_acm_certificate.test.*.arn[0/*@@_@@ TFMT:%[2]d:TFMT @@_@@*/]}"
   attr = aws_acm_certificate.test["@@_@@ TFMT:[%d]:TFMT @@_@@"].arn
   attr = "${aws_acm_certificate.test.*.arn[0/*@@_@@ TFMT:%d:TFMT @@_@@*/]}"
+}
+`,
+		},
+		{
+			name: "verb in for expression",
+			block: `
+resource "resource" "test" {
+  attr = [for x in range(1, %d+1) : element(aws_subnet.test[*].availability_zone, x)]
+  attr = [for x in range(1, %[2]d+1) : element(aws_subnet.test[*].availability_zone, x)]
+  attr = [for x in range(%d, 3) : element(aws_subnet.test[*].availability_zone, x)]
+  attr = [for x in range(%[1]d, 3) : element(aws_subnet.test[*].availability_zone, x)]
+  attr = [for x in range(%d, %d) : element(aws_subnet.test[*].availability_zone, x)]
+  attr = [for x in range(%[1]d, %[2]d) : element(aws_subnet.test[*].availability_zone, x)]
+}
+`,
+			expected: `
+resource "resource" "test" {
+  attr = [for x in range(1, TFMTFNPARAM_d+1) : element(aws_subnet.test[*].availability_zone, x)]
+  attr = [for x in range(1, TFMTFNPARAM_2d+1) : element(aws_subnet.test[*].availability_zone, x)]
+  attr = [for x in range(TFMTFNPARAM_d, 3) : element(aws_subnet.test[*].availability_zone, x)]
+  attr = [for x in range(TFMTFNPARAM_1d, 3) : element(aws_subnet.test[*].availability_zone, x)]
+  attr = [for x in range(TFMTFNPARAM_d, TFMTFNPARAM_d) : element(aws_subnet.test[*].availability_zone, x)]
+  attr = [for x in range(TFMTFNPARAM_1d, TFMTFNPARAM_2d) : element(aws_subnet.test[*].availability_zone, x)]
 }
 `,
 		},


### PR DESCRIPTION
`terrafmt` currently handles functions with a single parameter, such as `base64encode()` or `md5()`. Now allows functions with more parameters, such as `range()` for use in `for` expressions.

Closes #40
Closes #38