### PR TITLE
New flag: `no-color`

### DIFF
--- a/cli/cmds.go
+++ b/cli/cmds.go
@@ -227,7 +227,7 @@ func Make() *cobra.Command {
 	pflags.BoolP("check", "c", false, "return an error during diff if formatting is required")
 	pflags.BoolP("verbose", "v", false, "show files as they are processed& additional stats")
 	pflags.BoolP("quiet", "q", false, "quiet mode, only shows block line numbers ")
-	pflags.BoolP("no-color", "C", false, "disable colorful output")
+	pflags.BoolP("uncoloured", "u", false, "disable coloured output")
 
 	if err := viper.BindPFlag("fmtcompat", pflags.Lookup("fmtcompat")); err != nil {
 		panic(err)
@@ -241,14 +241,14 @@ func Make() *cobra.Command {
 	if err := viper.BindPFlag("verbose", pflags.Lookup("verbose")); err != nil {
 		panic(err)
 	}
-	if err := viper.BindPFlag("no-color", pflags.Lookup("no-color")); err != nil {
+	if err := viper.BindPFlag("uncoloured", pflags.Lookup("uncoloured")); err != nil {
 		panic(err)
 	}
 
 	//todo bind to env?
 
 	cobra.OnInitialize(func() {
-		if viper.GetBool("no-color") {
+		if viper.GetBool("uncoloured") {
 			c.Enable = false
 		}
 	})

--- a/cli/cmds.go
+++ b/cli/cmds.go
@@ -227,6 +227,7 @@ func Make() *cobra.Command {
 	pflags.BoolP("check", "c", false, "return an error during diff if formatting is required")
 	pflags.BoolP("verbose", "v", false, "show files as they are processed& additional stats")
 	pflags.BoolP("quiet", "q", false, "quiet mode, only shows block line numbers ")
+	pflags.BoolP("no-color", "C", false, "disable colorful output")
 
 	if err := viper.BindPFlag("fmtcompat", pflags.Lookup("fmtcompat")); err != nil {
 		panic(err)
@@ -240,9 +241,17 @@ func Make() *cobra.Command {
 	if err := viper.BindPFlag("verbose", pflags.Lookup("verbose")); err != nil {
 		panic(err)
 	}
+	if err := viper.BindPFlag("no-color", pflags.Lookup("no-color")); err != nil {
+		panic(err)
+	}
 
 	//todo bind to env?
 
+	cobra.OnInitialize(func() {
+		if viper.GetBool("no-color") {
+			c.Enable = false
+		}
+	})
 	return root
 }
 


### PR DESCRIPTION
Support `no-color` flag to suppress colorful output. This is useful when combining `terrafmt` with other tools via pipe. My use case is to combine `terrafmt blocks` together with https://github.com/magodo/hclgrep to filter certain pattern among acctests.