### PR TITLE
allow uppercase letters to resource name on block reader

### DIFF
--- a/lib/blocks/blockreader.go
+++ b/lib/blocks/blockreader.go
@@ -125,7 +125,7 @@ func (bv blockVisitor) Visit(cursor *astutil.Cursor) bool {
 	return true
 }
 
-var terraformMatcher = regexp.MustCompile(`(((resource|data)\s+"[-a-z0-9_]+")|(variable|output))\s+"[-a-z0-9_]+"\s+\{`)
+var terraformMatcher = regexp.MustCompile(`(((resource|data)\s+"[-a-z0-9_]+")|(variable|output))\s+"[-a-zA-Z0-9_]+"\s+\{`)
 
 // A simple check to see if the content looks like a Terraform configuration.
 // Looks for a line with either a resource, data source, variable, or output declaration


### PR DESCRIPTION
Uppercase letters in the resource name are allowed but the block reader doesn't detect the block in this case