### PR TITLE
allow capital letters to resource name on block reader

### DIFF
--- a/lib/blocks/blockreader.go
+++ b/lib/blocks/blockreader.go
@@ -115,7 +115,7 @@ func (bv blockVisitor) Visit(cursor *astutil.Cursor) bool {
 
 // Includes matching Go format verbs in the resource, data source, variable, or output name.
 // Technically, this is only valid for the Go matcher, but included generally for simplicity.
-var terraformMatcher = regexp.MustCompile(`(((resource|data)\s+"[-a-z0-9_]+")|(variable|output))\s+"[-a-z0-9_%\[\]]+"\s+\{`)
+var terraformMatcher = regexp.MustCompile(`(((resource|data)\s+"[-a-z0-9_]+")|(variable|output))\s+"[-a-zA-Z0-9_%\[\]]+"\s+\{`)
 
 // A simple check to see if the content looks like a Terraform configuration.
 // Looks for a line with either a resource, data source, variable, or output declaration

--- a/lib/blocks/blockreader_test.go
+++ b/lib/blocks/blockreader_test.go
@@ -104,6 +104,14 @@ func TestBlockDetection(t *testing.T) {
 }
 `,
 				},
+				{
+					leadingPadding:  "\n",
+					trailingPadding: "\n",
+					text: `resource "aws_s3_bucket" "UpperCase" {
+  bucket = "tf-test-bucket-with-uppercase"
+}
+`,
+				},
 			},
 		},
 		{
@@ -127,6 +135,12 @@ func TestBlockDetection(t *testing.T) {
 					text: `    
     resource "aws_s3_bucket" "leading-space-and-line" {
   bucket = "tf-test-bucket-leading-space-and-line"
+}
+`,
+				},
+				{
+					text: `resource "aws_s3_bucket" "UpperCase" {
+  bucket = "tf-test-bucket-with-uppercase"
 }
 `,
 				},

--- a/lib/blocks/testdata/test1.go
+++ b/lib/blocks/testdata/test1.go
@@ -83,6 +83,14 @@ resource "aws_s3_bucket" "%s" {
 `, name)
 }
 
+func testFormatUpperCase(name string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "UpperCase" {
+  bucket = "tf-test-bucket-with-uppercase"
+}
+`)
+}
+
 func notTerraformSimpleString() string {
 	fmt.Sprintf("%d: bad create: \n%#v\n%#v", i, cm, tc.Create)
 }

--- a/lib/blocks/testdata/test2.markdown
+++ b/lib/blocks/testdata/test2.markdown
@@ -32,3 +32,11 @@ Test block with leading whitespace and line
   bucket = "tf-test-bucket-leading-space-and-line"
 }
 ```
+
+Test block with capital letters in resource name
+
+```terraform
+resource "aws_s3_bucket" "UpperCase" {
+  bucket = "tf-test-bucket-with-uppercase"
+}
+```


### PR DESCRIPTION
Uppercase letters in the resource name are allowed but the block reader doesn't detect the block in this case.

The merge of MR #56 has been reverted by MR #67, so I recreate the same fix of #56 but with unit tests to avoid losing this fix again.